### PR TITLE
Add CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mbed-MCUboot Demo Bootloader
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MCUBOOT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mcuboot CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
+set(APP_TARGET bootloader)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+project(${APP_TARGET})
+
+add_subdirectory(${MBED_PATH})
+add_subdirectory(${MCUBOOT_PATH}/boot/bootutil/)
+add_subdirectory(${MCUBOOT_PATH}/boot/mbed/)  # Mbed-MCUboot Port
+
+add_executable(${APP_TARGET})
+
+target_sources(${APP_TARGET}
+    PUBLIC
+        default_bd.cpp
+        signing_keys.c
+)
+
+target_link_libraries(${APP_TARGET}
+    PUBLIC
+        bootutil
+        mbed-mcuboot
+        mbed-storage-spif
+        mbed-storage-qspif
+        mbed-baremetal
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/README.md
+++ b/README.md
@@ -280,15 +280,16 @@ Once your target has been programmed, open a serial terminal to view the debug o
 ```
 -- Terminal on /dev/ttyACM1 - 9600,8,N,1 ---
 [INFO][BL]: Starting MCUboot
-[INFO][MCUb]: Primary image: magic=good, swap_type=0x2, copy_done=0x1, image_ok=0x1
-[INFO][MCUb]: Scratch: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
-[INFO][MCUb]: Boot source: none
-[INFO][MCUb]: Swap type: none
+
+<Potentially random data from the UART>
+
 [INFO][BL]: Booting firmware image at 0x21000
 
 <Potentially random data from the UART>
 
-[INFO][main]: Hello version 1.2.3+4
+<Potentially random data from the UART>
+
+[INFO][main]: Regular boot
 [INFO][main]: > Press button to erase secondary slot
 
 ```
@@ -323,8 +324,6 @@ This causes the bootloader to check the secondary slot for a valid update binary
 You should see output similar to the following:
 
 ```
-[DBG ][MCUb]: writing magic; fa_id=1 off=0xbfff0 (0xbfff0)
-[DBG ][MCUb]: writing swap_info; fa_id=1 off=0xbffd8 (0xbffd8), swap_type=0x2 image_num=0x0
 [INFO][main]: > Secondary image pending, reboot to update
 ```
 
@@ -334,39 +333,26 @@ Now all you need to do to perform the update is reset your Mbed board! The mcubo
 
 ```
 [INFO][BL]: Starting MCUboot
-[INFO][MCUb]: Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
-[INFO][MCUb]: Scratch: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
-[INFO][MCUb]: Boot source: primary slot
-[INFO][MCUb]: Swap type: test
-[DBG ][MCUb]: erasing scratch area
-[DBG ][MCUb]: initializing status; fa_id=2
-[DBG ][MCUb]: writing swap_info; fa_id=2 off=0x1ffd8 (0xfffd8), swap_type=0x2 image_num=0x0
-[DBG ][MCUb]: writing swap_size; fa_id=2 off=0x1ffd0 (0xfffd0)
-[DBG ][MCUb]: writing magic; fa_id=2 off=0x1fff0 (0xffff0)
-[DBG ][MCUb]: erasing trailer; fa_id=0
-[DBG ][MCUb]: initializing status; fa_id=0
-[DBG ][MCUb]: writing swap_info; fa_id=0 off=0xbffd8 (0xdffd8), swap_type=0x2 image_num=0x0
-[DBG ][MCUb]: writing swap_size; fa_id=0 off=0xbffd0 (0xdffd0)
-[DBG ][MCUb]: writing magic; fa_id=0 off=0xbfff0 (0xdfff0)
-[DBG ][MCUb]: erasing trailer; fa_id=1
-[DBG ][MCUb]: writing copy_done; fa_id=0 off=0xbffe0 (0xdffe0)
+
+<Potentially random data from the UART>
+
 [INFO][BL]: Booting firmware image at 0x21000
 
 <Potentially random data from the UART>
 
-[INFO][main]: Boot confirmed
-[INFO][main]: Hello version 1.2.3+5
-[INFO][main]: > Press button to erase secondary slot
+[INFO][main]: Firmware update applied successfully
+[INFO][main]: Press the button to confirm, or reboot to revert the update
 ```
-
-Notice that the reported version number has changed! The update was performed successfully.
 
 **Note:** After an update is performed, the new application must mark itself as "okay" to the mcuboot bootloader. If this does not occur, mcuboot will revert the update upon the next reboot (if configured to do so).
 
-The blinky application in this demo always does this at startup:
+To make the update as "okay", press the button as instructed. This causes the application to call
+`boot_set_confirmed()`.
+
+Now you should see:
 
 ```
-int ret = boot_set_confirmed();
+[INFO][main]: Current firmware set as confirmed
 ```
 
-In real world situations, your application should run a self test routine to ensure it can receive updates in the future (eg: the UART software works as expected, the BLE stack initializes successfully, etc).
+**Note:** In real world situations, your application should run a self test routine to ensure it can receive updates in the future (eg: the UART software works as expected, the BLE stack initializes successfully, etc).

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ You should also install the python package `intelhex` if it is not already insta
 
 This python package includes several utility scripts for working with binaries and .hex files.
 
+By default, the demo application and bootloader are built as hex files to support flashing multiple images to different addresses. Some targets need to have the latest debug interface firmwares to support this, for example ST-LINK's firmware upgrader can be found [here](https://www.st.com/en/development-tools/stsw-link007.html). If your target does not support hex images, a single bin image with everything merged together can be used instead as will be described in [Merging it all together](#Merging-it-all-together) below.
+
 ### Creating the signing keys and building the bootloader
 
 This section will only cover steps specific to setting up this project with a signing key pair and signing a main application binary. For more advanced use cases and information, such as using alternative signing algorithms to rsa-2048, see the [mcuboot documentation on Image Signing](https://github.com/mcu-tools/mcuboot/blob/master/docs/signed_images.md#image-signing).
@@ -236,7 +238,9 @@ Other toolchains will have a similar utility to perform this step.
 
 ### Merging it all together
 
-To be able to drag-and-drop program the whole demo together, it is necessary to merge all the hex files we created in the last steps together.
+Usually, if your target supports hex files, you can drag-and-drop one image at a time (waiting for each to finish) to program them into their respective locations.
+
+If your target doesn't support hex files or performs a whole chip erase upon every drag-and-drop action, it is necessary to merge all the hex files we created in the last steps together.
 
 At this step, you should have created three hex files:
 - mbed-mcuboot-demo.hex (the bootloader)

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -23,8 +23,7 @@
             "mcuboot.scratch-address": "0xE0000",
             "mcuboot.scratch-size": "0x20000",
             "mcuboot.max-img-sectors": "0x180",
-            "mcuboot.read-granularity": 4,
-            "qspif.QSPI_MIN_PROG_SIZE": 4
+            "mcuboot.read-granularity": 4
         },
         "EP_AGORA": {
             "target.features_remove": ["CRYPTOCELL310"],
@@ -34,8 +33,7 @@
             "mcuboot.scratch-address": "0xE0000",
             "mcuboot.scratch-size": "0x20000",
             "mcuboot.max-img-sectors": "0x180",
-            "mcuboot.read-granularity": 4,
-            "qspif.QSPI_MIN_PROG_SIZE": 4
+            "mcuboot.read-granularity": 4
         },
         "DISCO_L475VG_IOT01A": {
             "mcuboot.primary-slot-address": "0x8020000",

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -10,6 +10,7 @@
         "*": {
             "target.restrict_size": "0x20000",
             "target.c_lib": "small",
+            "target.OUTPUT_EXT": "hex",
             "mcuboot.log-level": "MCUBOOT_LOG_LEVEL_DEBUG",
             "mbed-trace.enable": true,
             "mbed-trace.fea-ipv6": false

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -42,9 +42,7 @@
             "mcuboot.slot-size": "0xC0000",
             "mcuboot.scratch-address": "0x80E0000",
             "mcuboot.scratch-size": "0x20000",
-            "mcuboot.max-img-sectors": "0x180",
-            "mcuboot.read-granularity": 1,
-            "qspif.QSPI_MIN_PROG_SIZE": 1
+            "mcuboot.max-img-sectors": "0x180"
         }
     }
 }

--- a/mcuboot.lib
+++ b/mcuboot.lib
@@ -1,1 +1,1 @@
-https://github.com/mcu-tools/mcuboot.git
+https://github.com/lambda-shuttle/mcuboot.git


### PR DESCRIPTION
As mentioned in mcu-tools/mcuboot#1153, 

"_Currently, MbedOS applications using this port require that they are built with the old mbed-cli. However, `mbed-tools` is the new, future command-line tool for MbedOS; `mbed-tools` is also known as Mbed CLI 2. This new tool makes use of "Ninja as a build system, and CMake to generate the build environment and manage the build process in a compiler-independent manner." More information can be found [here](https://os.mbed.com/docs/mbed-os/v6.12/build-tools/mbed-cli-2.html)._"

A CMakeLists.txt was added as a result; the `mcuboot.lib` now points to this [fork](https://github.com/lambda-shuttle/mcuboot). This pull request has a companion [pull request](https://github.com/AGlass0fMilk/mbed-mcuboot-blinky/pull/5) in the `mbed-mcuboot-blinky` application repository; both are required for the full mbed-tools build workflow. 

**Note:** This pull requests builds on the changes from #13. 

@LDong-Arm 